### PR TITLE
Updated stats handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- Support for Puma v3 state files
+- Parsing of stats output with multiple workers
+- Ability to pass `--control-url` and `--auth-token` directly instead of state file
+- Support for connecting to control servers running on TCP ports
+
+### Removed
+- Dependency on `puma`
 
 ## [1.0.0] - 2017-06-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - Parsing of stats output with multiple workers
 - Ability to pass `--control-url` and `--auth-token` directly instead of state file
 - Support for connecting to control servers running on TCP ports
+- Add `--gc-stats` flag to allow collecting GC stats
 
 ### Removed
 - Dependency on `puma`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+
+### Breaking Change
+- updated `sensu-plugin` dependency to 2.x (@majormoses)
+
 ### Added
 - Support for Puma v3 state files
 - Parsing of stats output with multiple workers
@@ -44,4 +48,3 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 [1.0.0]: https://github.com/sensu-plugins/sensu-plugins-puma/compare/0.0.3...1.0.0
 [0.0.3]: https://github.com/sensu-plugins/sensu-plugins-puma/compare/0.0.2...0.0.3
 [0.0.2]: https://github.com/sensu-plugins/sensu-plugins-puma/compare/0.0.1...0.0.2
-

--- a/bin/metrics-puma.rb
+++ b/bin/metrics-puma.rb
@@ -70,7 +70,7 @@ class PumaMetrics < Sensu::Plugin::Metric::CLI::Graphite
     timestamp = Time.now.to_i
     stats = puma_ctl.stats
     metrics = {}
-    worker_status = stats.delete("worker_status")
+    worker_status = stats.delete('worker_status')
 
     if worker_status
       metrics = parse_worker_stats(metrics, worker_status)
@@ -79,7 +79,7 @@ class PumaMetrics < Sensu::Plugin::Metric::CLI::Graphite
     metrics.merge!(stats)
 
     metrics = parse_gc_stats(metrics, puma_ctl.gc_stats) if config[:gc_stats]
-    
+
     metrics.map do |k, v|
       output "#{config[:scheme]}.#{k}", v, timestamp
     end
@@ -87,6 +87,7 @@ class PumaMetrics < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   private
+
   def parse_gc_stats(metrics, gc_stats)
     gc_stats.map do |k, v|
       metrics["gc.#{k}"] = v
@@ -95,19 +96,20 @@ class PumaMetrics < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def parse_worker_stats(metrics, worker_status)
-    backlog, running = 0, 0
+    backlog = 0
+    running = 0
     worker_status.each do |worker|
-      idx = worker.delete("index")
-      last_status = worker.delete("last_status")
-      backlog += (worker["backlog"] = last_status["backlog"])
-      running += (worker["running"] = last_status["running"])
+      idx = worker.delete('index')
+      last_status = worker.delete('last_status')
+      backlog += (worker['backlog'] = last_status['backlog'])
+      running += (worker['running'] = last_status['running'])
       worker.map do |k, v|
         metrics["worker.#{idx}.#{k}"] = v
       end
     end
 
-    metrics["backlog"] = backlog
-    metrics["running"] = running
+    metrics['backlog'] = backlog
+    metrics['running'] = running
     metrics
   end
 end

--- a/bin/metrics-puma.rb
+++ b/bin/metrics-puma.rb
@@ -78,7 +78,11 @@ class PumaMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
     metrics.merge!(stats)
 
-    metrics = parse_gc_stats(metrics, puma_ctl.gc_stats) if config[:gc_stats]
+    begin
+      metrics = parse_gc_stats(metrics, puma_ctl.gc_stats) if config[:gc_stats]
+    rescue PumaCtl::UnknownCommand
+      unknown 'Control server does not support the `gc-stats` command'
+    end
 
     metrics.map do |k, v|
       output "#{config[:scheme]}.#{k}", v, timestamp

--- a/bin/metrics-puma.rb
+++ b/bin/metrics-puma.rb
@@ -29,7 +29,6 @@
 require 'sensu-plugin/metric/cli'
 
 require 'json'
-require 'puma/configuration'
 require 'socket'
 require 'yaml'
 
@@ -46,16 +45,41 @@ class PumaMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--state-file SOCKET',
          default: '/tmp/puma.state'
 
+  option :control_auth_token,
+         description: 'The auth token to connect to the control server with',
+         long: '--auth-token TOKEN'
+
+  option :control_url,
+         description: 'The control_url the puma control server is listening on',
+         long: '--control-url PATH'
+
+  def control_auth_token
+    @control_auth_token ||= (config[:control_auth_token] || puma_options[:control_auth_token])
+  end
+
+  def control_url
+    @control_url ||= (config[:control_url] || puma_options[:control_url])
+  end
+
   def puma_options
     @puma_options ||= begin
       return nil unless File.exist?(config[:state_file])
-      YAML.load_file(config[:state_file])['config'].options
+      state = load_puma_state(config[:state_file])
+
+      if state.has_key?('config')
+        # state is < v3.0.0
+        opts = state['config']['options']
+        {control_url: opts[:control_url], control_auth_token: opts[:control_auth_token]}
+      else
+        # state is >= v3.0.0
+        {control_url: state['control_url'], control_auth_token: state['control_auth_token']}
+      end
     end
   end
 
   def puma_stats
-    stats = Socket.unix(puma_options[:control_url].gsub('unix://', '')) do |socket|
-      socket.print("GET /stats?token=#{puma_options[:control_auth_token]} HTTP/1.0\r\n\r\n")
+    stats = Socket.unix(control_url.gsub('unix://', '')) do |socket|
+      socket.print("GET /stats?token=#{control_auth_token} HTTP/1.0\r\n\r\n")
       socket.read
     end
 
@@ -67,5 +91,13 @@ class PumaMetrics < Sensu::Plugin::Metric::CLI::Graphite
       output "#{config[:scheme]}.#{k}", v
     end
     ok
+  end
+
+  private
+
+  def load_puma_state(path)
+    raw = File.read(path)
+    sanitized = raw.gsub(/!ruby\/object:.*$/, '')
+    YAML.load(sanitized)
   end
 end

--- a/bin/metrics-puma.rb
+++ b/bin/metrics-puma.rb
@@ -104,6 +104,7 @@ class PumaMetrics < Sensu::Plugin::Metric::CLI::Graphite
       backlog += (worker['backlog'] = last_status['backlog'])
       running += (worker['running'] = last_status['running'])
       worker.map do |k, v|
+        v = Time.parse(v).to_i if k == 'last_checkin'
         metrics["worker.#{idx}.#{k}"] = v
       end
     end

--- a/lib/sensu-plugins-puma.rb
+++ b/lib/sensu-plugins-puma.rb
@@ -1,1 +1,2 @@
 require 'sensu-plugins-puma/version'
+require 'sensu-plugins-puma/puma_ctl'

--- a/lib/sensu-plugins-puma/puma_ctl.rb
+++ b/lib/sensu-plugins-puma/puma_ctl.rb
@@ -24,13 +24,13 @@ class PumaCtl
       return nil unless File.exist?(state_file)
       state = load_puma_state(state_file)
 
-      if state.has_key?('config')
+      if state.key?('config')
         # state is < v3.0.0
         opts = state['config']['options']
-        {control_url: opts[:control_url], control_auth_token: opts[:control_auth_token]}
+        { control_url: opts[:control_url], control_auth_token: opts[:control_auth_token] }
       else
         # state is >= v3.0.0
-        {control_url: state['control_url'], control_auth_token: state['control_auth_token']}
+        { control_url: state['control_url'], control_auth_token: state['control_auth_token'] }
       end
     end
   end
@@ -55,7 +55,7 @@ class PumaCtl
     when /^tcp:\/\//
       type = :tcp
       args = control_url.gsub('tcp://', '').split(':')
-    else 
+    else
       return nil
     end
 

--- a/lib/sensu-plugins-puma/puma_ctl.rb
+++ b/lib/sensu-plugins-puma/puma_ctl.rb
@@ -1,0 +1,76 @@
+require 'json'
+require 'socket'
+require 'yaml'
+
+class PumaCtl
+  attr_reader :state_file
+
+  def initialize(state_file: '/tmp/puma.state', control_auth_token: nil, control_url: nil)
+    @state_file = state_file
+    @control_auth_token = control_auth_token
+    @control_url = control_url
+  end
+
+  def control_auth_token
+    @control_auth_token ||= puma_options[:control_auth_token]
+  end
+
+  def control_url
+    @control_url ||= puma_options[:control_url]
+  end
+
+  def puma_options
+    @puma_options ||= begin
+      return nil unless File.exist?(state_file)
+      state = load_puma_state(state_file)
+
+      if state.has_key?('config')
+        # state is < v3.0.0
+        opts = state['config']['options']
+        {control_url: opts[:control_url], control_auth_token: opts[:control_auth_token]}
+      else
+        # state is >= v3.0.0
+        {control_url: state['control_url'], control_auth_token: state['control_auth_token']}
+      end
+    end
+  end
+
+  def stats
+    send_socket_command('stats')
+  end
+
+  private
+
+  def control_socket
+    type = nil
+    args = []
+    case control_url
+    when /^unix:\/\//
+      type = :unix
+      args = [control_url.gsub('unix://', '')]
+    when /^tcp:\/\//
+      type = :tcp
+      args = control_url.gsub('tcp://', '').split(':')
+    else 
+      return nil
+    end
+
+    Socket.send(type, *args) do |socket|
+      yield socket
+    end
+  end
+
+  def load_puma_state(path)
+    raw = File.read(path)
+    sanitized = raw.gsub(/!ruby\/object:.*$/, '')
+    YAML.load(sanitized)
+  end
+
+  def send_socket_command(cmd)
+    out = control_socket do |socket|
+      socket.print("GET /#{cmd}?token=#{control_auth_token} HTTP/1.0\r\n\r\n")
+      socket.read
+    end
+    JSON.parse(out.split("\r\n").last)
+  end
+end

--- a/lib/sensu-plugins-puma/puma_ctl.rb
+++ b/lib/sensu-plugins-puma/puma_ctl.rb
@@ -35,6 +35,10 @@ class PumaCtl
     end
   end
 
+  def gc_stats
+    send_socket_command('gc-stats')
+  end
+
   def stats
     send_socket_command('stats')
   end

--- a/sensu-plugins-puma.gemspec
+++ b/sensu-plugins-puma.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsPuma::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin', '~> 2.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'

--- a/sensu-plugins-puma.gemspec
+++ b/sensu-plugins-puma.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsPuma::Version::VER_STRING
 
-  s.add_runtime_dependency 'puma',         '2.11.3'
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'

--- a/test/bin/metrics-puma_spec.rb
+++ b/test/bin/metrics-puma_spec.rb
@@ -6,6 +6,10 @@ class PumaMetrics
   at_exit do
     @@autorun = false
   end
+
+  def ok(*)
+    'ok'
+  end
 end
 
 describe PumaMetrics do
@@ -31,7 +35,6 @@ describe PumaMetrics do
 
     before do
       allow(metric).to receive(:output)
-      allow(metric).to receive(:ok)
       allow(puma_ctl).to receive(:stats) { stats_output }
       allow(puma_ctl).to receive(:gc_stats) { gc_stats_output }
       metric.run

--- a/test/bin/metrics-puma_spec.rb
+++ b/test/bin/metrics-puma_spec.rb
@@ -1,5 +1,5 @@
-require_relative './spec_helper'
-require_relative '../bin/metrics-puma'
+require_relative '../spec_helper'
+require_relative '../../bin/metrics-puma'
 require 'pry'
 
 class PumaMetrics

--- a/test/bin/metrics-puma_spec.rb
+++ b/test/bin/metrics-puma_spec.rb
@@ -4,7 +4,9 @@ require 'pry'
 
 class PumaMetrics
   at_exit do
+    # rubocop:disable Style/ClassVars
     @@autorun = false
+    # rubocop:enable Style/ClassVars
   end
 
   def ok(*)

--- a/test/lib/puma_ctl_spec.rb
+++ b/test/lib/puma_ctl_spec.rb
@@ -70,6 +70,17 @@ describe PumaCtl do
       it 'returns the JSON socket response as a hash' do
         expect(puma_ctl.gc_stats).to eq('heap_used' => 1516)
       end
+
+      context 'when `gc-stats` is not supported' do
+        before do
+          allow(socket).to receive(:print)
+        end
+
+        it 'raises an error' do
+          allow(socket).to receive(:read).and_return("HTTP/1.0 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: 18\r\n\r\nUnsupported action")
+          expect { puma_ctl.gc_stats }.to raise_error(PumaCtl::UnknownCommand, 'gc-stats')
+        end
+      end
     end
 
     context 'with a UNIX socket control url' do
@@ -87,6 +98,17 @@ describe PumaCtl do
 
       it 'returns the JSON socket response as a hash' do
         expect(puma_ctl.gc_stats).to eq('heap_used' => 1516)
+      end
+
+      context 'when `gc-stats` is not supported' do
+        before do
+          allow(socket).to receive(:print)
+        end
+
+        it 'raises an error' do
+          allow(socket).to receive(:read).and_return("HTTP/1.0 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: 18\r\n\r\nUnsupported action")
+          expect { puma_ctl.gc_stats }.to raise_error(PumaCtl::UnknownCommand, 'gc-stats')
+        end
       end
     end
   end

--- a/test/lib/puma_ctl_spec.rb
+++ b/test/lib/puma_ctl_spec.rb
@@ -43,6 +43,55 @@ describe PumaCtl do
     end
   end
 
+  describe "#gc_stats" do
+    let(:control_auth_token) {'123'}
+    let(:state_file_path) {nil}
+    let(:socket) {spy('socket')}
+
+    before do
+      allow(socket).to receive(:read).and_return(%Q( HTTP\/1.1 200 OK\r\n{"heap_used": 1516}))
+      allow(Socket).to receive(:tcp).and_yield(socket)
+      allow(Socket).to receive(:unix).and_yield(socket)
+    end
+
+    context 'with a TCP control url' do
+      let(:control_url) {'tcp://192.1.1.25:9191'}
+
+      it 'connects to the TCP socket' do
+        puma_ctl.gc_stats
+        expect(Socket).to have_received(:tcp).with('192.1.1.25', '9191')
+      end
+
+      it 'sends the correct command to the control server' do
+        expect(socket).to receive(:print).with("GET /gc-stats?token=#{control_auth_token} HTTP/1.0\r\n\r\n")
+        puma_ctl.gc_stats
+      end
+
+      it 'returns the JSON socket response as a hash' do
+        expect(puma_ctl.gc_stats).to eq("heap_used" => 1516)
+      end
+    end
+
+    context 'with a UNIX socket control url' do
+      let(:control_url) {'unix:///some/path'}
+
+      it 'connects to the socket' do
+        puma_ctl.gc_stats
+        expect(Socket).to have_received(:unix).with('/some/path')
+      end
+
+      it 'sends the correct command to the control server' do
+        expect(socket).to receive(:print).with("GET /gc-stats?token=#{control_auth_token} HTTP/1.0\r\n\r\n")
+        puma_ctl.gc_stats
+      end
+
+      it 'returns the JSON socket response as a hash' do
+        expect(puma_ctl.gc_stats).to eq("heap_used" => 1516)
+      end
+    end
+
+  end
+
   describe "#stats" do
     let(:control_auth_token) {'123'}
     let(:state_file_path) {nil}

--- a/test/lib/puma_ctl_spec.rb
+++ b/test/lib/puma_ctl_spec.rb
@@ -1,0 +1,95 @@
+require_relative '../spec_helper'
+require 'sensu-plugins-puma/puma_ctl'
+
+require 'socket'
+
+describe PumaCtl do
+  subject(:puma_ctl) {PumaCtl.new(state_file: state_file_path, control_auth_token: control_auth_token, control_url: control_url)}
+  let(:control_auth_token) {nil}
+  let(:control_url) {nil}
+  let(:state_file_path) {File.join(File.dirname(__FILE__), "../support/v#{version}.state")}
+  let(:version) {nil}
+
+  context 'configuration' do
+    context 'with control options' do
+      let(:control_auth_token) {'123'}
+      let(:control_url) {'unix:///some/path'}
+
+      it 'accepts a `control_auth_token`' do
+        expect(puma_ctl.control_auth_token).to eq('123')
+      end
+
+      it 'accepts a `control-url` option' do
+        expect(puma_ctl.control_url).to eq('unix:///some/path')
+      end
+    end
+
+    context "with a < v3.0.0 state file" do
+      let(:version) {'2x'}
+
+      it "parses correctly" do
+        expect(puma_ctl.control_auth_token).to eq('abcde')
+        expect(puma_ctl.control_url).to eq('unix:///app/pumactl.sock')
+      end
+    end
+
+    context "with a >= v3.0.0 state file" do
+      let(:version) {'3x'}
+
+      it "parses correctly" do
+        expect(puma_ctl.control_auth_token).to eq('123456')
+        expect(puma_ctl.control_url).to eq('unix:///app/pumactl.sock')
+      end
+    end
+  end
+
+  describe "#stats" do
+    let(:control_auth_token) {'123'}
+    let(:state_file_path) {nil}
+    let(:socket) {spy('socket')}
+
+    before do
+      allow(socket).to receive(:read).and_return(%Q( HTTP\/1.1 200 OK\r\n{"running": 0}))
+      allow(Socket).to receive(:tcp).and_yield(socket)
+      allow(Socket).to receive(:unix).and_yield(socket)
+    end
+
+    context 'with a TCP control url' do
+      let(:control_url) {'tcp://192.1.1.25:9191'}
+
+      it 'connects to the TCP socket' do
+        puma_ctl.stats
+        expect(Socket).to have_received(:tcp).with('192.1.1.25', '9191')
+      end
+
+      it 'sends the correct command to the control server' do
+        expect(socket).to receive(:print).with("GET /stats?token=#{control_auth_token} HTTP/1.0\r\n\r\n")
+        puma_ctl.stats
+      end
+
+      it 'returns the JSON socket response as a hash' do
+        expect(puma_ctl.stats).to eq("running" => 0)
+      end
+    end
+
+    context 'with a UNIX socket control url' do
+      let(:control_url) {'unix:///some/path'}
+
+      it 'connects to the socket' do
+        puma_ctl.stats
+        expect(Socket).to have_received(:unix).with('/some/path')
+      end
+
+      it 'sends the correct command to the control server' do
+        expect(socket).to receive(:print).with("GET /stats?token=#{control_auth_token} HTTP/1.0\r\n\r\n")
+        puma_ctl.stats
+      end
+
+      it 'returns the JSON socket response as a hash' do
+        expect(puma_ctl.stats).to eq("running" => 0)
+      end
+    end
+
+  end
+
+end

--- a/test/lib/puma_ctl_spec.rb
+++ b/test/lib/puma_ctl_spec.rb
@@ -4,16 +4,16 @@ require 'sensu-plugins-puma/puma_ctl'
 require 'socket'
 
 describe PumaCtl do
-  subject(:puma_ctl) {PumaCtl.new(state_file: state_file_path, control_auth_token: control_auth_token, control_url: control_url)}
-  let(:control_auth_token) {nil}
-  let(:control_url) {nil}
-  let(:state_file_path) {File.join(File.dirname(__FILE__), "../support/v#{version}.state")}
-  let(:version) {nil}
+  subject(:puma_ctl) { PumaCtl.new(state_file: state_file_path, control_auth_token: control_auth_token, control_url: control_url) }
+  let(:control_auth_token) { nil }
+  let(:control_url) { nil }
+  let(:state_file_path) { File.join(File.dirname(__FILE__), "../support/v#{version}.state") }
+  let(:version) { nil }
 
   context 'configuration' do
     context 'with control options' do
-      let(:control_auth_token) {'123'}
-      let(:control_url) {'unix:///some/path'}
+      let(:control_auth_token) { '123' }
+      let(:control_url) { 'unix:///some/path' }
 
       it 'accepts a `control_auth_token`' do
         expect(puma_ctl.control_auth_token).to eq('123')
@@ -24,38 +24,38 @@ describe PumaCtl do
       end
     end
 
-    context "with a < v3.0.0 state file" do
-      let(:version) {'2x'}
+    context 'with a < v3.0.0 state file' do
+      let(:version) { '2x' }
 
-      it "parses correctly" do
+      it 'parses correctly' do
         expect(puma_ctl.control_auth_token).to eq('abcde')
         expect(puma_ctl.control_url).to eq('unix:///app/pumactl.sock')
       end
     end
 
-    context "with a >= v3.0.0 state file" do
-      let(:version) {'3x'}
+    context 'with a >= v3.0.0 state file' do
+      let(:version) { '3x' }
 
-      it "parses correctly" do
+      it 'parses correctly' do
         expect(puma_ctl.control_auth_token).to eq('123456')
         expect(puma_ctl.control_url).to eq('unix:///app/pumactl.sock')
       end
     end
   end
 
-  describe "#gc_stats" do
-    let(:control_auth_token) {'123'}
-    let(:state_file_path) {nil}
-    let(:socket) {spy('socket')}
+  describe '#gc_stats' do
+    let(:control_auth_token) { '123' }
+    let(:state_file_path) { nil }
+    let(:socket) { spy('socket') }
 
     before do
-      allow(socket).to receive(:read).and_return(%Q( HTTP\/1.1 200 OK\r\n{"heap_used": 1516}))
+      allow(socket).to receive(:read).and_return(%( HTTP\/1.1 200 OK\r\n{"heap_used": 1516}))
       allow(Socket).to receive(:tcp).and_yield(socket)
       allow(Socket).to receive(:unix).and_yield(socket)
     end
 
     context 'with a TCP control url' do
-      let(:control_url) {'tcp://192.1.1.25:9191'}
+      let(:control_url) { 'tcp://192.1.1.25:9191' }
 
       it 'connects to the TCP socket' do
         puma_ctl.gc_stats
@@ -68,12 +68,12 @@ describe PumaCtl do
       end
 
       it 'returns the JSON socket response as a hash' do
-        expect(puma_ctl.gc_stats).to eq("heap_used" => 1516)
+        expect(puma_ctl.gc_stats).to eq('heap_used' => 1516)
       end
     end
 
     context 'with a UNIX socket control url' do
-      let(:control_url) {'unix:///some/path'}
+      let(:control_url) { 'unix:///some/path' }
 
       it 'connects to the socket' do
         puma_ctl.gc_stats
@@ -86,25 +86,24 @@ describe PumaCtl do
       end
 
       it 'returns the JSON socket response as a hash' do
-        expect(puma_ctl.gc_stats).to eq("heap_used" => 1516)
+        expect(puma_ctl.gc_stats).to eq('heap_used' => 1516)
       end
     end
-
   end
 
-  describe "#stats" do
-    let(:control_auth_token) {'123'}
-    let(:state_file_path) {nil}
-    let(:socket) {spy('socket')}
+  describe '#stats' do
+    let(:control_auth_token) { '123' }
+    let(:state_file_path) { nil }
+    let(:socket) { spy('socket') }
 
     before do
-      allow(socket).to receive(:read).and_return(%Q( HTTP\/1.1 200 OK\r\n{"running": 0}))
+      allow(socket).to receive(:read).and_return(%( HTTP\/1.1 200 OK\r\n{"running": 0}))
       allow(Socket).to receive(:tcp).and_yield(socket)
       allow(Socket).to receive(:unix).and_yield(socket)
     end
 
     context 'with a TCP control url' do
-      let(:control_url) {'tcp://192.1.1.25:9191'}
+      let(:control_url) { 'tcp://192.1.1.25:9191' }
 
       it 'connects to the TCP socket' do
         puma_ctl.stats
@@ -117,12 +116,12 @@ describe PumaCtl do
       end
 
       it 'returns the JSON socket response as a hash' do
-        expect(puma_ctl.stats).to eq("running" => 0)
+        expect(puma_ctl.stats).to eq('running' => 0)
       end
     end
 
     context 'with a UNIX socket control url' do
-      let(:control_url) {'unix:///some/path'}
+      let(:control_url) { 'unix:///some/path' }
 
       it 'connects to the socket' do
         puma_ctl.stats
@@ -135,10 +134,8 @@ describe PumaCtl do
       end
 
       it 'returns the JSON socket response as a hash' do
-        expect(puma_ctl.stats).to eq("running" => 0)
+        expect(puma_ctl.stats).to eq('running' => 0)
       end
     end
-
   end
-
 end

--- a/test/metrics-puma_spec.rb
+++ b/test/metrics-puma_spec.rb
@@ -3,42 +3,104 @@ require_relative '../bin/metrics-puma'
 require 'pry'
 
 describe PumaMetrics do
-  subject(:check) {PumaMetrics.new(args)}
+  subject(:metric) {PumaMetrics.new(args)}
   let(:args) {}
-  let(:state_file_path) {File.join(File.dirname(__FILE__), "support/v#{version}.state")}
-
 
   context 'with options' do
-    let(:args) {%w(--auth-token 123 --control-url unix:///some/path)}
-    it 'accepts an `auth-token` option' do
-      expect(check.control_auth_token).to eq('123')
-    end
+    let(:args) {%w(--state-file /some/file.state --auth-token 123 --control-url unix:///some/path)}
 
-    it 'accepts a `control-url` option' do
-      expect(check.control_url).to eq('unix:///some/path')
-    end
-  end
-
-  context "with a < v3.0.0 state file" do
-    let(:version) {'2x'}
-    let(:args) {%W(--state-file #{state_file_path})}
-
-    it "parses correctly" do
-      expect(check.control_auth_token).to eq('abcde')
-      expect(check.control_url).to eq('unix:///app/pumactl.sock')
-    end
-  end
-
-  context "with a >= v3.0.0 state file" do
-    let(:version) {'3x'}
-    let(:args) {%W(--state-file #{state_file_path})}
-
-    it "parses correctly" do
-      expect(check.control_auth_token).to eq('123456')
-      expect(check.control_url).to eq('unix:///app/pumactl.sock')
+    it 'correctly instantiates a PumaCtl instnace' do
+      # poor test
+      expect(PumaCtl).to receive(:new).with(state_file: '/some/file.state', control_auth_token: '123', control_url: 'unix:///some/path')
+      metric.puma_ctl
     end
   end
 
   describe '#run' do
+    let(:args) {%w(--scheme test --auth-token 123 --control-url unix:///path)}
+    let(:puma_ctl) {metric.puma_ctl}
+
+    before do
+      allow(metric).to receive(:output)
+      allow(metric).to receive(:ok)
+      allow(puma_ctl).to receive(:stats) {stats_output}
+      metric.run
+    end
+
+    context 'gathering stats' do
+      context 'with one worker' do
+        let(:stats_output) { {"backlog" => 1, "running" => 2} }
+
+        it "outputs the correct stats" do
+          expect(metric).to output("test.backlog", 1)
+          expect(metric).to output("test.running", 2)
+        end
+      end
+
+      context 'with multiple workers' do
+        let (:stats_output) { {
+          "workers" => 2,
+          "phase" => 0,
+          "booted_workers" => 2,
+          "old_workers" => 0,
+          "worker_status" => [{ 
+            "pid" => 4122,
+            "index" => 1,
+            "phase" => 0,
+            "booted" => true,
+            "last_checkin" => "2017-08-23T01:44:01Z",
+            "last_status" => { "backlog" =>0, "running" =>2 } 
+          },
+          { 
+            "pid" => 4126,
+            "index" => 0,
+            "phase" => 0,
+            "booted" => true,
+            "last_checkin" => "2017-08-23T01:44:01Z",
+            "last_status" => { "backlog" =>1, "running" =>1 } 
+          }] 
+        } }
+
+        it "outputs the main stats" do
+          expect(metric).to output("test.workers", 2)
+          expect(metric).to output("test.phase", 0)
+          expect(metric).to output("test.booted_workers", 2)
+          expect(metric).to output("test.old_workers", 0)
+        end
+
+        it "outputs the stats for each worker" do
+          expect(metric).to output("test.worker.1.pid", 4122)
+          expect(metric).to output("test.worker.1.phase", 0)
+          expect(metric).to output("test.worker.1.booted", true)
+          expect(metric).to output("test.worker.1.last_checkin", "2017-08-23T01:44:01Z")
+          expect(metric).to output("test.worker.1.backlog", 0)
+          expect(metric).to output("test.worker.1.running", 2)
+
+          expect(metric).to output("test.worker.0.pid", 4126)
+          expect(metric).to output("test.worker.0.phase", 0)
+          expect(metric).to output("test.worker.0.booted", true)
+          expect(metric).to output("test.worker.0.last_checkin", "2017-08-23T01:44:01Z")
+          expect(metric).to output("test.worker.0.backlog", 1)
+          expect(metric).to output("test.worker.0.running", 1)
+        end
+
+        it "outputs the worker stats according to their index" do
+          expect(metric).to output("test.worker.0.pid", 4126)
+          expect(metric).to output("test.worker.1.pid", 4122)
+        end
+
+        it "outputs the aggregated backlog and running stats" do
+          expect(metric).to output("test.backlog", 1)
+          expect(metric).to output("test.running", 3)
+        end
+      end
+
+    end
+  end
+
+  RSpec::Matchers.define :output do |key, val|
+    match do |metric|
+      expect(metric).to have_received(:output).with(key, val, instance_of(Fixnum))
+    end
   end
 end

--- a/test/metrics-puma_spec.rb
+++ b/test/metrics-puma_spec.rb
@@ -53,7 +53,7 @@ describe PumaMetrics do
               'index' => 1,
               'phase' => 0,
               'booted' => true,
-              'last_checkin' => '2017-08-23T01:44:01Z',
+              'last_checkin' => '2017-08-23T01:44:00Z',
               'last_status' => { 'backlog' => 0, 'running' => 2 }
             },
                                 {
@@ -78,14 +78,14 @@ describe PumaMetrics do
           expect(metric).to output('test.worker.1.pid', 4122)
           expect(metric).to output('test.worker.1.phase', 0)
           expect(metric).to output('test.worker.1.booted', true)
-          expect(metric).to output('test.worker.1.last_checkin', '2017-08-23T01:44:01Z')
+          expect(metric).to output('test.worker.1.last_checkin', 1_503_452_640)
           expect(metric).to output('test.worker.1.backlog', 0)
           expect(metric).to output('test.worker.1.running', 2)
 
           expect(metric).to output('test.worker.0.pid', 4126)
           expect(metric).to output('test.worker.0.phase', 0)
           expect(metric).to output('test.worker.0.booted', true)
-          expect(metric).to output('test.worker.0.last_checkin', '2017-08-23T01:44:01Z')
+          expect(metric).to output('test.worker.0.last_checkin', 1_503_452_641)
           expect(metric).to output('test.worker.0.backlog', 1)
           expect(metric).to output('test.worker.0.running', 1)
         end

--- a/test/metrics-puma_spec.rb
+++ b/test/metrics-puma_spec.rb
@@ -3,11 +3,11 @@ require_relative '../bin/metrics-puma'
 require 'pry'
 
 describe PumaMetrics do
-  subject(:metric) {PumaMetrics.new(args)}
+  subject(:metric) { PumaMetrics.new(args) }
   let(:args) {}
 
   context 'with options' do
-    let(:args) {%w(--state-file /some/file.state --auth-token 123 --control-url unix:///some/path)}
+    let(:args) { %w(--state-file /some/file.state --auth-token 123 --control-url unix:///some/path) }
 
     it 'correctly instantiates a PumaCtl instnace' do
       # poor test
@@ -17,105 +17,106 @@ describe PumaMetrics do
   end
 
   describe '#run' do
-    let(:args) {%W(--scheme test --auth-token 123 --control-url unix:///path #{additional_args})}
-    let(:additional_args) {''}
-    let(:puma_ctl) {metric.puma_ctl}
-    let(:stats_output) {{}}
-    let(:gc_stats_output) {{}}
+    let(:args) { %W(--scheme test --auth-token 123 --control-url unix:///path #{additional_args}) }
+    let(:additional_args) { '' }
+    let(:puma_ctl) { metric.puma_ctl }
+    let(:stats_output) { {} }
+    let(:gc_stats_output) { {} }
 
     before do
       allow(metric).to receive(:output)
       allow(metric).to receive(:ok)
-      allow(puma_ctl).to receive(:stats) {stats_output}
-      allow(puma_ctl).to receive(:gc_stats) {gc_stats_output}
+      allow(puma_ctl).to receive(:stats) { stats_output }
+      allow(puma_ctl).to receive(:gc_stats) { gc_stats_output }
       metric.run
     end
 
     context 'gathering stats' do
       context 'with one worker' do
-        let(:stats_output) { {"backlog" => 1, "running" => 2} }
+        let(:stats_output) { { 'backlog' => 1, 'running' => 2 } }
 
-        it "outputs the correct stats" do
-          expect(metric).to output("test.backlog", 1)
-          expect(metric).to output("test.running", 2)
+        it 'outputs the correct stats' do
+          expect(metric).to output('test.backlog', 1)
+          expect(metric).to output('test.running', 2)
         end
       end
 
       context 'with multiple workers' do
-        let (:stats_output) { {
-          "workers" => 2,
-          "phase" => 0,
-          "booted_workers" => 2,
-          "old_workers" => 0,
-          "worker_status" => [{ 
-            "pid" => 4122,
-            "index" => 1,
-            "phase" => 0,
-            "booted" => true,
-            "last_checkin" => "2017-08-23T01:44:01Z",
-            "last_status" => { "backlog" =>0, "running" =>2 } 
-          },
-          { 
-            "pid" => 4126,
-            "index" => 0,
-            "phase" => 0,
-            "booted" => true,
-            "last_checkin" => "2017-08-23T01:44:01Z",
-            "last_status" => { "backlog" =>1, "running" =>1 } 
-          }] 
-        } }
-
-        it "outputs the main stats" do
-          expect(metric).to output("test.workers", 2)
-          expect(metric).to output("test.phase", 0)
-          expect(metric).to output("test.booted_workers", 2)
-          expect(metric).to output("test.old_workers", 0)
+        let(:stats_output) do
+          {
+            'workers' => 2,
+            'phase' => 0,
+            'booted_workers' => 2,
+            'old_workers' => 0,
+            'worker_status' => [{
+              'pid' => 4122,
+              'index' => 1,
+              'phase' => 0,
+              'booted' => true,
+              'last_checkin' => '2017-08-23T01:44:01Z',
+              'last_status' => { 'backlog' => 0, 'running' => 2 }
+            },
+                                {
+                                  'pid' => 4126,
+                                  'index' => 0,
+                                  'phase' => 0,
+                                  'booted' => true,
+                                  'last_checkin' => '2017-08-23T01:44:01Z',
+                                  'last_status' => { 'backlog' => 1, 'running' => 1 }
+                                }]
+          }
         end
 
-        it "outputs the stats for each worker" do
-          expect(metric).to output("test.worker.1.pid", 4122)
-          expect(metric).to output("test.worker.1.phase", 0)
-          expect(metric).to output("test.worker.1.booted", true)
-          expect(metric).to output("test.worker.1.last_checkin", "2017-08-23T01:44:01Z")
-          expect(metric).to output("test.worker.1.backlog", 0)
-          expect(metric).to output("test.worker.1.running", 2)
-
-          expect(metric).to output("test.worker.0.pid", 4126)
-          expect(metric).to output("test.worker.0.phase", 0)
-          expect(metric).to output("test.worker.0.booted", true)
-          expect(metric).to output("test.worker.0.last_checkin", "2017-08-23T01:44:01Z")
-          expect(metric).to output("test.worker.0.backlog", 1)
-          expect(metric).to output("test.worker.0.running", 1)
+        it 'outputs the main stats' do
+          expect(metric).to output('test.workers', 2)
+          expect(metric).to output('test.phase', 0)
+          expect(metric).to output('test.booted_workers', 2)
+          expect(metric).to output('test.old_workers', 0)
         end
 
-        it "outputs the worker stats according to their index" do
-          expect(metric).to output("test.worker.0.pid", 4126)
-          expect(metric).to output("test.worker.1.pid", 4122)
+        it 'outputs the stats for each worker' do
+          expect(metric).to output('test.worker.1.pid', 4122)
+          expect(metric).to output('test.worker.1.phase', 0)
+          expect(metric).to output('test.worker.1.booted', true)
+          expect(metric).to output('test.worker.1.last_checkin', '2017-08-23T01:44:01Z')
+          expect(metric).to output('test.worker.1.backlog', 0)
+          expect(metric).to output('test.worker.1.running', 2)
+
+          expect(metric).to output('test.worker.0.pid', 4126)
+          expect(metric).to output('test.worker.0.phase', 0)
+          expect(metric).to output('test.worker.0.booted', true)
+          expect(metric).to output('test.worker.0.last_checkin', '2017-08-23T01:44:01Z')
+          expect(metric).to output('test.worker.0.backlog', 1)
+          expect(metric).to output('test.worker.0.running', 1)
         end
 
-        it "outputs the aggregated backlog and running stats" do
-          expect(metric).to output("test.backlog", 1)
-          expect(metric).to output("test.running", 3)
+        it 'outputs the worker stats according to their index' do
+          expect(metric).to output('test.worker.0.pid', 4126)
+          expect(metric).to output('test.worker.1.pid', 4122)
+        end
+
+        it 'outputs the aggregated backlog and running stats' do
+          expect(metric).to output('test.backlog', 1)
+          expect(metric).to output('test.running', 3)
         end
       end
-
     end
 
     context 'gathering gc stats' do
-      let(:gc_stats_output) {{"heap_used" => 1516, "heap_length" => 1519}}
+      let(:gc_stats_output) { { 'heap_used' => 1516, 'heap_length' => 1519 } }
 
       context 'without the `--gc-stats` flag' do
-        it "does not try to gather gc stats" do
+        it 'does not try to gather gc stats' do
           expect(puma_ctl).to_not have_received(:gc_stats)
         end
       end
 
       context 'with the `--gc-stats` flag' do
-        let(:additional_args) {'--gc-stats'}
+        let(:additional_args) { '--gc-stats' }
 
         it "outputs the gc stats with a 'gc' prefix" do
-          expect(metric).to output("test.gc.heap_used", 1516)
-          expect(metric).to output("test.gc.heap_length", 1519)
+          expect(metric).to output('test.gc.heap_used', 1516)
+          expect(metric).to output('test.gc.heap_length', 1519)
         end
       end
     end

--- a/test/metrics-puma_spec.rb
+++ b/test/metrics-puma_spec.rb
@@ -1,0 +1,44 @@
+require_relative './spec_helper'
+require_relative '../bin/metrics-puma'
+require 'pry'
+
+describe PumaMetrics do
+  subject(:check) {PumaMetrics.new(args)}
+  let(:args) {}
+  let(:state_file_path) {File.join(File.dirname(__FILE__), "support/v#{version}.state")}
+
+
+  context 'with options' do
+    let(:args) {%w(--auth-token 123 --control-url unix:///some/path)}
+    it 'accepts an `auth-token` option' do
+      expect(check.control_auth_token).to eq('123')
+    end
+
+    it 'accepts a `control-url` option' do
+      expect(check.control_url).to eq('unix:///some/path')
+    end
+  end
+
+  context "with a < v3.0.0 state file" do
+    let(:version) {'2x'}
+    let(:args) {%W(--state-file #{state_file_path})}
+
+    it "parses correctly" do
+      expect(check.control_auth_token).to eq('abcde')
+      expect(check.control_url).to eq('unix:///app/pumactl.sock')
+    end
+  end
+
+  context "with a >= v3.0.0 state file" do
+    let(:version) {'3x'}
+    let(:args) {%W(--state-file #{state_file_path})}
+
+    it "parses correctly" do
+      expect(check.control_auth_token).to eq('123456')
+      expect(check.control_url).to eq('unix:///app/pumactl.sock')
+    end
+  end
+
+  describe '#run' do
+  end
+end

--- a/test/metrics-puma_spec.rb
+++ b/test/metrics-puma_spec.rb
@@ -2,6 +2,12 @@ require_relative './spec_helper'
 require_relative '../bin/metrics-puma'
 require 'pry'
 
+class PumaMetrics
+  at_exit do
+    @@autorun = false
+  end
+end
+
 describe PumaMetrics do
   subject(:metric) { PumaMetrics.new(args) }
   let(:args) {}

--- a/test/metrics-puma_spec.rb
+++ b/test/metrics-puma_spec.rb
@@ -48,22 +48,24 @@ describe PumaMetrics do
             'phase' => 0,
             'booted_workers' => 2,
             'old_workers' => 0,
-            'worker_status' => [{
-              'pid' => 4122,
-              'index' => 1,
-              'phase' => 0,
-              'booted' => true,
-              'last_checkin' => '2017-08-23T01:44:00Z',
-              'last_status' => { 'backlog' => 0, 'running' => 2 }
-            },
-                                {
-                                  'pid' => 4126,
-                                  'index' => 0,
-                                  'phase' => 0,
-                                  'booted' => true,
-                                  'last_checkin' => '2017-08-23T01:44:01Z',
-                                  'last_status' => { 'backlog' => 1, 'running' => 1 }
-                                }]
+            'worker_status' => [
+              {
+                'pid' => 4122,
+                'index' => 1,
+                'phase' => 0,
+                'booted' => true,
+                'last_checkin' => '2017-08-23T01:44:00Z',
+                'last_status' => { 'backlog' => 0, 'running' => 2 }
+              },
+              {
+                'pid' => 4126,
+                'index' => 0,
+                'phase' => 0,
+                'booted' => true,
+                'last_checkin' => '2017-08-23T01:44:01Z',
+                'last_status' => { 'backlog' => 1, 'running' => 1 }
+              }
+            ]
           }
         end
 

--- a/test/support/v2x.state
+++ b/test/support/v2x.state
@@ -1,0 +1,31 @@
+---
+pid: 11305
+config: !ruby/object:Puma::Configuration
+  cli_options: 
+  conf: 
+  options:
+    :min_threads: 2
+    :max_threads: 4
+    :quiet: false
+    :debug: false
+    :binds:
+    - unix:///app/puma.sock
+    :workers: 2
+    :daemon: false
+    :mode: :http
+    :before_fork:
+    - !ruby/object:Proc {}
+    :worker_timeout: 60
+    :worker_boot_timeout: 60
+    :worker_shutdown_timeout: 30
+    :environment: development
+    :redirect_stdout: "/app/log/puma.stdout.log"
+    :redirect_stderr: "/app/log/puma.stderr.log"
+    :redirect_append: true
+    :pidfile: "/app/tmp/pids/puma.pid"
+    :state: tmp/puma.state
+    :preload_app: true
+    :control_url: unix:///app/pumactl.sock
+    :control_auth_token: 'abcde'
+    :config_file: config/puma.rb
+    :tag: core

--- a/test/support/v3x.state
+++ b/test/support/v3x.state
@@ -1,0 +1,4 @@
+---
+pid: 28383
+control_url: unix:///app/pumactl.sock
+control_auth_token: '123456'


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Yes, #3 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
This pull request adds the following:
- Support for Puma v3 state files
- Parsing of stats output with multiple workers
- Ability to pass `--control-url` and `--auth-token` directly instead of state file
- Support for connecting to control servers running on TCP ports
- Add `--gc-stats` flag to allow collecting GC stats

It also removes the dependency on `puma`

#### Known Compatability Issues
This should be fully backward compatible with the existing plugin functionality, and with all versions of Puma that support a control server.
